### PR TITLE
build: remove --depth 1 from git clone in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,8 @@ ENV PATH="$PATH:$FLUTTER_ROOT/bin:$FLUTTER_ROOT/bin/cache/dart-sdk/bin"
 
 ARG flutter_version
 
+# TODO: Add --depth 1 after https://github.com/flutter/flutter/issues/163198 is fixed
 RUN git clone \
-    --depth 1 \
     --branch "$flutter_version" \
     https://github.com/flutter/flutter.git \
     "$FLUTTER_ROOT" \


### PR DESCRIPTION
## What

Clones the full branch of the flutter version tag instead of only the latest commit.

## Why

The version 3.29.0 uses git when running the flutter CLI and that is causing [fatal: Not a valid object name origin/master](https://github.com/gmeligio/flutter-docker-image/actions/runs/13302670208/job/37180550313#step:8:8)

That is reported in https://github.com/flutter/flutter/issues/163198 and due to the usage of the git CLI as 
`git -C "$FLUTTER_ROOT" merge-base HEAD origin/master` in https://github.com/flutter/flutter/blob/87196771eb0119ffc9d23a644bd4209eb19d5eef/bin/internal/update_engine_version.sh#L50