### PR TITLE
build: replace yq with cue to reduce tool dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,8 +109,8 @@ jobs:
 
       - name: Validate version.json and flutter_version.json
         run: |
-          cue vet config/version.cue config/version.json
-          cue vet config/flutter_version.cue config/flutter_version.json
+          cue vet config/version.cue -d '#FlutterVersion' config/flutter_version.json
+          cue vet config/version.cue -d '#Version' config/version.json
 
   validate_generated_config:
     runs-on: ubuntu-24.04
@@ -118,10 +118,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
+      - name: Setup Cue
+        uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
+
       - name: Generate test files
-        uses: mikefarah/yq@bbdd97482f2d439126582a59689eb1c855944955 # v4
-        with:
-          cmd: ./script/update_test.sh
+        run: |
+          ./script/update_test.sh
 
       - name: Check if there are any changes in the git working tree
         run: |
@@ -200,4 +202,4 @@ jobs:
         uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
 
       - name: Validate version.json
-        run: cue vet config/version.cue config/version.json
+        run: cue vet config/version.cue -d '#Version' config/version.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,10 +104,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - name: Setup Cue for JSON validation
+      - name: Setup CUE
         uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
 
-      - name: Validate version.json and flutter_version.json
+      - name: Validate version.json and flutter_version.json with CUE
         run: |
           cue vet config/version.cue -d '#FlutterVersion' config/flutter_version.json
           cue vet config/version.cue -d '#Version' config/version.json
@@ -118,10 +118,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - name: Setup Cue
+      - name: Setup CUE
         uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
 
-      - name: Generate test files
+      - name: Generate test files with CUE
         run: |
           ./script/update_test.sh
 
@@ -198,8 +198,8 @@ jobs:
           cat ../../script/updateAndroidVersions.gradle.kts >> app/build.gradle.kts
           ./gradlew --warning-mode all updateAndroidVersions
 
-      - name: Setup Cue for JSON validation
+      - name: Setup CUE
         uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
 
-      - name: Validate version.json
+      - name: Validate version.json with CUE
         run: cue vet config/version.cue -d '#Version' config/version.json

--- a/.github/workflows/update_flutter_dependencies.yml
+++ b/.github/workflows/update_flutter_dependencies.yml
@@ -73,10 +73,10 @@ jobs:
         run: |
           rm -rf test_app
 
-      - name: Setup Cue for JSON validation
+      - name: Setup CUE
         uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
 
-      - name: Validate version.json
+      - name: Validate version.json with CUE
         run: cue vet config/version.cue -d '#Version' config/version.json
 
       - name: Setup NodeJS

--- a/.github/workflows/update_flutter_dependencies.yml
+++ b/.github/workflows/update_flutter_dependencies.yml
@@ -77,7 +77,7 @@ jobs:
         uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
 
       - name: Validate version.json
-        run: cue vet config/version.cue config/version.json
+        run: cue vet config/version.cue -d '#Version' config/version.json
 
       - name: Setup NodeJS
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4

--- a/.github/workflows/update_flutter_version.yml
+++ b/.github/workflows/update_flutter_version.yml
@@ -37,7 +37,7 @@ jobs:
         uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
 
       - name: Validate version.json
-        run: cue vet config/flutter_version.cue config/flutter_version.json
+        run: cue vet config/version.cue -d '#FlutterVersion' config/flutter_version.json
 
       - name: Create commit message variable
         run: |

--- a/.github/workflows/update_flutter_version.yml
+++ b/.github/workflows/update_flutter_version.yml
@@ -33,10 +33,10 @@ jobs:
             const script = require('./script/updateFlutterVersion.js')
             await script({core, fetch})
 
-      - name: Setup Cue for JSON validation
+      - name: Setup CUE
         uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
 
-      - name: Validate version.json
+      - name: Validate version.json with CUE
         run: cue vet config/version.cue -d '#FlutterVersion' config/flutter_version.json
 
       - name: Create commit message variable

--- a/config/android.cue
+++ b/config/android.cue
@@ -1,0 +1,29 @@
+#FileContentTests: {
+	name: string
+	path: _
+	expectedContents: [string]
+}
+
+#ContainerStructureTest: {
+	schemaVersion: _
+	commandTests: _
+	fileContentTests: [...#FileContentTests]
+}
+
+input: #ContainerStructureTest
+
+android_cmdline_tools_version: string @tag(android_cmdline_tools_version)
+android_cmdline_tools_test_expected_content: string @tag(android_cmdline_tools_test_expected_content)
+
+output: {
+	schemaVersion: input.schemaVersion
+	commandTests: input.commandTests
+	fileContentTests: [
+		{
+			name: "Android SDK Command-line Tools is version \(android_cmdline_tools_version)"
+			path: input.fileContentTests[0].path
+			expectedContents: [android_cmdline_tools_test_expected_content]
+		},
+		input.fileContentTests[1]
+	]
+}

--- a/config/version.cue
+++ b/config/version.cue
@@ -13,20 +13,27 @@ import "list"
 	version!: =~ "^\\d+.\\d+.\\d+$"
 }
 
+#FlutterVersion: {
+	flutter: {
+		channel!: "stable" | "beta"
+		commit!:  strings.MaxRunes(40)
+		#PatchVersion
+	}
+}
 
 #MinorOrPatchVersion: #MinorVersion | #PatchVersion
 
-flutter: {
-	channel!: "stable" | "beta"
-	commit!:  strings.MaxRunes(40)
-	#PatchVersion
-}
+#Version: {
+	#FlutterVersion
 
-android: {
-	platforms!: [...#PlatformVersion] & list.MinItems(1) & list.UniqueItems
-	gradle!: #MinorOrPatchVersion
-	buildTools!: #PatchVersion
-	cmdlineTools!: #MinorVersion
-}
+	android: {
+		platforms!: [...#PlatformVersion] & list.MinItems(1) & list.UniqueItems
+		gradle!: #MinorOrPatchVersion
+		buildTools!: #PatchVersion
+		cmdlineTools!: #MinorVersion
+		ndk!: #PatchVersion
+		cmake!: #PatchVersion
+	}
 
-fastlane!: #PatchVersion
+	fastlane!: #PatchVersion
+}

--- a/script/update_test.sh
+++ b/script/update_test.sh
@@ -3,9 +3,10 @@
 # Path to the JSON and YAML files
 version_file_path="./config/version.json"
 test_file_path="./test/android.yml"
+temp_file_path="./test/temp.yml"
 
 # Extracting the version value from the version.json file
-android_cmdline_tools_version=$(yq -oy '.android.cmdlineTools.version' "$version_file_path")
+android_cmdline_tools_version=$(cue eval --expression 'android.cmdlineTools.version' "$version_file_path" | sed 's/^"\(.*\)"$/\1/')
 android_cmdline_tools_test_expected_content="Pkg.Revision=$android_cmdline_tools_version
 Pkg.Path=cmdline-tools;$android_cmdline_tools_version
 Pkg.Desc=Android SDK Command-line Tools"
@@ -16,9 +17,10 @@ if [ -z "$android_cmdline_tools_version" ]; then
     exit 1
 fi
 
-# Update the YAML file using yq
-# Replace 'path.to.version' with the actual path to the version field in the YAML file
-yq -i ".fileContentTests[0].name = \"Android SDK Command-line Tools is version $android_cmdline_tools_version\" | .fileContentTests[0].expectedContents[0] = \"$android_cmdline_tools_test_expected_content\"" "$test_file_path"
 
-# Verify the update
+# Update the version YAML file using cue
+cue export config/android.cue -l input: ./test/android.yml -t android_cmdline_tools_version="$android_cmdline_tools_version" -t android_cmdline_tools_test_expected_content="$android_cmdline_tools_test_expected_content" -e output --out yaml >"$temp_file_path"
+mv "$temp_file_path" "$test_file_path"
+
+# Write progress
 echo "Updated $test_file_path with android_cmdline_tools_version: $android_cmdline_tools_version"

--- a/test/android.yml
+++ b/test/android.yml
@@ -50,7 +50,10 @@ commandTests:
         - /home/flutter/test_app/android/fastlane/Appfile
       - - sh
         - -c
-        - "echo 'lane :hello do\n puts \"Hello\"\nend' > /home/flutter/test_app/android/fastlane/Fastfile"
+        - |-
+          echo 'lane :hello do
+           puts "Hello"
+          end' > /home/flutter/test_app/android/fastlane/Fastfile
       - - touch
         - /home/flutter/test_app/android/fastlane/Pluginfile
     teardown:
@@ -78,7 +81,10 @@ fileContentTests:
   - name: Android SDK Command-line Tools is version 12.0
     path: /home/flutter/sdks/android-sdk/cmdline-tools/latest/source.properties
     expectedContents:
-      - "Pkg.Revision=12.0\nPkg.Path=cmdline-tools;12.0\nPkg.Desc=Android SDK Command-line Tools"
+      - |-
+        Pkg.Revision=12.0
+        Pkg.Path=cmdline-tools;12.0
+        Pkg.Desc=Android SDK Command-line Tools
   - name: Dart and Flutter analytics are disabled
     path: /home/flutter/.dart-tool/dart-flutter-telemetry.config
     expectedContents:


### PR DESCRIPTION
`cue` can generate a YAML file and parse a JSON file. Let's use it instead of `yq`. The same thing might be possible for `jq`.