### PR TITLE
ci: replace jq with cue to reduce tool dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Read environment variables from version.json
+      - name: Setup CUE
+        uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
+
+      - name: Read environment variables from version.json with CUE
         env:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           IMAGE_REPOSITORY_NAME: ${{ env.IMAGE_REPOSITORY_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,10 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Read environment variables from version.json
+      - name: Setup CUE
+        uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
+
+      - name: Read environment variables from version.json with CUE
         env:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           IMAGE_REPOSITORY_NAME: ${{ env.IMAGE_REPOSITORY_NAME }}
@@ -102,7 +105,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - name: Read environment variables from version.json
+      - name: Setup CUE
+        uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
+
+      - name: Read environment variables from version.json with CUE
         env:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           IMAGE_REPOSITORY_NAME: ${{ env.IMAGE_REPOSITORY_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,10 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Read environment variables from version.json
+      - name: Setup CUE
+        uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
+
+      - name: Read environment variables from version.json with CUE
         env:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           IMAGE_REPOSITORY_NAME: ${{ env.IMAGE_REPOSITORY_NAME }}

--- a/script/set_environment_variables.sh
+++ b/script/set_environment_variables.sh
@@ -1,19 +1,17 @@
 #!/usr/bin/env bash
 
-IMAGE_REPOSITORY_PATH="$GITHUB_REPOSITORY_OWNER/$IMAGE_REPOSITORY_NAME"
-
 {
-    echo "FLUTTER_VERSION=$(jq -r '.flutter.version' "$VERSION_MANIFEST")"
+    echo "FLUTTER_VERSION=$(cue eval -e 'flutter.version' "$VERSION_MANIFEST" | tr -d '"')"
 
-    echo "FASTLANE_VERSION=$(jq -r '.fastlane.version' "$VERSION_MANIFEST")"
+    echo "FASTLANE_VERSION=$(cue eval -e 'fastlane.version' "$VERSION_MANIFEST" | tr -d '"')"
 
-    echo "ANDROID_BUILD_TOOLS_VERSION=$(jq -r '.android.buildTools.version' "$VERSION_MANIFEST")"
+    echo "ANDROID_BUILD_TOOLS_VERSION=$(cue eval -e 'android.buildTools.version' "$VERSION_MANIFEST" | tr -d '"')"
 
-    echo "ANDROID_PLATFORM_VERSIONS=$(jq -r '.android.platforms[].version' "$VERSION_MANIFEST" | tr '\n' ' ' | sed 's/ $//')"
+    echo "ANDROID_PLATFORM_VERSIONS=$(cue eval -e 'strings.Join([for p in android.platforms {"\(p.version)"}], " ")' "$VERSION_MANIFEST" | tr -d '"\n')"
 
-    echo "ANDROID_NDK_VERSION=$(jq -r '.android.ndk.version' "$VERSION_MANIFEST")"
+    echo "ANDROID_NDK_VERSION=$(cue eval -e 'android.ndk.version' "$VERSION_MANIFEST" | tr -d '"')"
 
-    echo "CMAKE_VERSION=$(jq -r '.android.cmake.version' "$VERSION_MANIFEST")"
+    echo "CMAKE_VERSION=$(cue eval -e 'android.cmake.version' "$VERSION_MANIFEST" | tr -d '"')"
 
-    echo "IMAGE_REPOSITORY_PATH=$IMAGE_REPOSITORY_PATH"
+    echo "IMAGE_REPOSITORY_PATH=$GITHUB_REPOSITORY_OWNER/$IMAGE_REPOSITORY_NAME"
 } >>"$GITHUB_ENV"

--- a/script/update_test.sh
+++ b/script/update_test.sh
@@ -6,7 +6,7 @@ test_file_path="./test/android.yml"
 temp_file_path="./test/temp.yml"
 
 # Extracting the version value from the version.json file
-android_cmdline_tools_version=$(cue eval --expression 'android.cmdlineTools.version' "$version_file_path" | sed 's/^"\(.*\)"$/\1/')
+android_cmdline_tools_version=$(cue eval -e 'android.cmdlineTools.version' "$version_file_path" | tr -d '"')
 android_cmdline_tools_test_expected_content="Pkg.Revision=$android_cmdline_tools_version
 Pkg.Path=cmdline-tools;$android_cmdline_tools_version
 Pkg.Desc=Android SDK Command-line Tools"


### PR DESCRIPTION
`cue` can read from JSON files with a concise syntax similar to `jq`. Let's use it instead of `jq`.