### PR TITLE
fix(deps): bump yaml from 2.8.2 to 2.8.3

### DIFF
--- a/docs/src/package-lock.json
+++ b/docs/src/package-lock.json
@@ -3213,9 +3213,9 @@
             }
         },
         "node_modules/yaml": {
-            "version": "2.8.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"


### PR DESCRIPTION
## Summary
- Bumps `yaml` from 2.8.2 to 2.8.3 in `docs/src/package-lock.json`
- Fixes CVE-2026-33532: Stack Overflow via deeply nested YAML collections (medium severity)
- Resolves https://github.com/gmeligio/flutter-docker-image/security/dependabot/9

## Test plan
- [ ] Verify `docs/src` build still works (`npm run build`)
- [ ] Confirm Dependabot alert is auto-closed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)