### PR TITLE
ci: skip secret-dependent steps on fork PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      # Secrets are not available to PRs from forks, so skip the Docker Hub
+      # login for those runs. The build still works against public base images.
       - name: Login to Docker Hub
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -84,8 +87,11 @@ jobs:
           config: test/android.yml
 
       # TODO: Parallelize testing and vulnerability scanning
+      # Scout needs the Docker Hub org secret and writes a PR comment, neither
+      # of which is available to fork PRs.
       - name: Scan with Docker Scout
         id: docker-scout
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/scout-action@f8c776824083494ab0d56b8105ba2ca85c86e4de # v1.18.2
         with:
           command: compare, recommendations
@@ -156,7 +162,10 @@ jobs:
           cache-dependency-path: docs/src/package-lock.json
           node-version: lts/*
 
+      # The GitHub App token and the commit/push step are not available to
+      # fork PRs. Still run the doc build to verify it compiles.
       - name: Generate authentication token with GitHub App to trigger Actions
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: app-token
         with:
@@ -172,6 +181,7 @@ jobs:
           npm run build
 
       - name: Commit and push documentation
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: grafana/github-api-commit-action@b1d81091e8480dd11fcea8bc1f0ab977a0376ca5 # v1.0.0
         with:
           commit-message: 'docs: generate documentation files'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,7 +23,11 @@ jobs:
       - name: Clean runner disk
         uses: ./.github/actions/clean-runner-disk-windows
 
+      # Secrets are not available to PRs from forks. The Windows base image
+      # comes from mcr.microsoft.com, so Docker Hub auth is not strictly
+      # required to build/test the image.
       - name: Login to Docker Hub
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
## Summary

PRs opened from forks (e.g. #445) cannot access repository secrets, so the Docker Hub login, Docker Scout scan, and docs commit/push steps fail before the actual build runs. This gates each of those steps on the PR coming from the same repository, so fork PRs can still validate the build/test steps against public base images.

### Changes

- **`.github/workflows/build.yml`**
  - `test_image`: skip "Login to Docker Hub" and "Scan with Docker Scout" on fork PRs
  - `build_docs`: skip "Generate authentication token" and "Commit and push documentation" on fork PRs (the `npm run build` step still runs, so the docs build is still validated)
- **`.github/workflows/windows.yml`**
  - `test_windows`: skip "Login to Docker Hub" on fork PRs (the Windows base image is from `mcr.microsoft.com`, so Docker Hub auth is not needed for the build)

### Why not `pull_request_target`?

That event would run untrusted fork code with access to repository secrets, which is a known security footgun for build/test workflows. The conditional-skip approach is safer: fork code never sees the secrets.

### Trade-offs

- Fork PR builds pull base images anonymously from Docker Hub, which is subject to anonymous rate limits. With buildx caching and only one Debian base image, this should rarely matter in practice. If rate limits start biting later, the next step would be a dedicated CI-only Docker Hub token exposed via a GitHub Environment with required reviewers.
- Docker Scout vulnerability scanning is silently skipped for fork PRs. Maintainers can re-run the scan by pushing the same commit to a branch in this repo if they want Scout output before merging.

## Test plan

- [ ] Confirm the new conditionals don't break runs from same-repo PRs (the existing same-repo workflow_dispatch / push paths use `github.event_name != 'pull_request'` so they're unaffected)
- [ ] After merge, re-trigger CI on #445 (or open a fresh fork PR) and verify that `test_image`, `test_windows`, and `build_docs` complete green with the secret-dependent steps reported as skipped
- [ ] Verify Docker Hub login / Scout / docs commit still execute on a maintainer-pushed branch


---
_Generated by [Claude Code](https://claude.ai/code/session_01ArqrGXYbwkio1jc2UgvE1v)_