### PR TITLE
ci: make workflows fork-PR friendly by removing vars.FLUTTER_VERSION

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Resolves the bootstrap container tag — the latest published release tag.
+  # Reading from the releases API (instead of vars.FLUTTER_VERSION) makes
+  # fork PRs work, and reading from releases (instead of main's version.json)
+  # avoids the window between merging a version-bump PR and publishing its
+  # image during which main's version.json points to a tag that doesn't
+  # exist in GHCR yet.
+  setup:
+    runs-on: ubuntu-24.04
+    outputs:
+      flutter_version: ${{ steps.read.outputs.version }}
+    steps:
+      - name: Read latest release tag
+        id: read
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version=$(gh api "repos/${{ github.repository }}/releases/latest" --jq '.tag_name')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
   test_image:
     permissions:
       # Allow to write packages for the docker/scout-action to write a comment
@@ -152,8 +171,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Setup NodeJS
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
@@ -162,40 +179,34 @@ jobs:
           cache-dependency-path: docs/src/package-lock.json
           node-version: lts/*
 
-      # The GitHub App token and the commit/push step are not available to
-      # fork PRs. Still run the doc build to verify it compiles.
-      - name: Generate authentication token with GitHub App to trigger Actions
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        id: app-token
-        with:
-          app-id: ${{ secrets.VERIFIED_COMMIT_ID }}
-          private-key: ${{ secrets.VERIFIED_COMMIT_KEY }}
-          repositories: ${{ github.event.repository.name }}
-          owner: ${{ github.repository_owner }}
-
-      - name: Update documentation
+      - name: Build documentation
         working-directory: docs/src
         run: |
           npm ci --prefer-offline
           npm run build
 
-      - name: Commit and push documentation
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: grafana/github-api-commit-action@b1d81091e8480dd11fcea8bc1f0ab977a0376ca5 # v1.0.0
+      # Upload generated docs so reviewers can inspect them. Commit-back is
+      # handled by update_docs.yml on push to main — pushing to fork PR
+      # branches is not possible with base-repo credentials.
+      - name: Upload built docs
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          commit-message: 'docs: generate documentation files'
-          success-if-no-changes: true
-          stage-all-files: true
-          token: ${{ steps.app-token.outputs.token }}
+          name: docs-${{ github.event.pull_request.number || github.sha }}
+          path: |
+            readme.md
+            LICENSE.md
+            docs/contributing.md
+            docs/windows.md
+          retention-days: 14
 
   test_gradle:
+    needs: setup
     permissions:
       # Allow to read packages to pull the container image from GitHub Container Registry
       packages: read
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/${{ github.repository_owner }}/flutter-android:${{ vars.FLUTTER_VERSION }}
+      image: ghcr.io/${{ github.repository_owner }}/flutter-android:${{ needs.setup.outputs.flutter_version }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,28 +235,6 @@ jobs:
         with:
           sarif_file: sarif.json
 
-  set_bootstrap_image:
-    runs-on: ubuntu-24.04
-    needs: release_android
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-
-      - name: Generate authentication token with GitHub App to trigger Actions
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        id: app-token
-        with:
-          app-id: ${{ secrets.VERIFIED_COMMIT_ID }}
-          private-key: ${{ secrets.VERIFIED_COMMIT_KEY }}
-          repositories: ${{ github.event.repository.name }}
-          owner: ${{ github.repository_owner }}
-
-      - name: Update bootstrap image tag in environment variable
-        run: gh variable set FLUTTER_VERSION --body "${{ env.FLUTTER_VERSION }}"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
   create_github_release:
     permissions:
       # Allow to create releases and upload assets to them

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Create Tag for a New Flutter Version
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
-          OLD_FLUTTER_VERSION: ${{ vars.FLUTTER_VERSION }}
           NEW_FLUTTER_VERSION: ${{ env.FLUTTER_VERSION }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -1,0 +1,47 @@
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/src/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update_docs:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          cache: npm
+          cache-dependency-path: docs/src/package-lock.json
+          node-version: lts/*
+
+      - name: Build documentation
+        working-directory: docs/src
+        run: |
+          npm ci --prefer-offline
+          npm run build
+
+      - name: Generate authentication token with GitHub App to trigger Actions
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ secrets.VERIFIED_COMMIT_ID }}
+          private-key: ${{ secrets.VERIFIED_COMMIT_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Commit and push regenerated documentation
+        uses: grafana/github-api-commit-action@b1d81091e8480dd11fcea8bc1f0ab977a0376ca5 # v1.0.0
+        with:
+          commit-message: 'docs: regenerate documentation files'
+          success-if-no-changes: true
+          stage-all-files: true
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update_version.yml
+++ b/.github/workflows/update_version.yml
@@ -11,6 +11,20 @@ env:
   FLUTTER_VERSION_PATH: config/flutter_version.json
 
 jobs:
+  # Resolves the bootstrap container tag — the latest published release tag.
+  setup:
+    runs-on: ubuntu-24.04
+    outputs:
+      flutter_version: ${{ steps.read.outputs.version }}
+    steps:
+      - name: Read latest release tag
+        id: read
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version=$(gh api "repos/${{ github.repository }}/releases/latest" --jq '.tag_name')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
   update_flutter_version:
     permissions:
       # Allow to write contents to push commits
@@ -77,14 +91,14 @@ jobs:
       packages: read
       # Allow to write pull requests to create a pull request
       pull-requests: write
-    needs: update_flutter_version
+    needs: [setup, update_flutter_version]
     if: ${{ needs.update_flutter_version.outputs.new_version == 'true' }}
     outputs:
       version_artifact_id: ${{ steps.upload-version.outputs.artifact-id }}
       android_test_artifact_id: ${{ steps.upload-android-test.outputs.artifact-id }}
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/${{ github.repository_owner }}/flutter-android:${{ vars.FLUTTER_VERSION }}
+      image: ghcr.io/${{ github.repository_owner }}/flutter-android:${{ needs.setup.outputs.flutter_version }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ github.token }}

--- a/script/createGitTag.js
+++ b/script/createGitTag.js
@@ -1,20 +1,25 @@
 module.exports = async ({ core, context, github }) => {
-  const { OLD_FLUTTER_VERSION, NEW_FLUTTER_VERSION } = process.env
-
-  if (!OLD_FLUTTER_VERSION) {
-    core.setFailed('Environment variable OLD_FLUTTER_VERSION is required.')
-  }
+  const { NEW_FLUTTER_VERSION } = process.env
 
   if (!NEW_FLUTTER_VERSION) {
     core.setFailed('Environment variable NEW_FLUTTER_VERSION is required.')
-  }
-
-  if (OLD_FLUTTER_VERSION === NEW_FLUTTER_VERSION) {
     return
   }
 
+  // If a tag for this version already exists, do nothing.
+  try {
+    await github.rest.git.getRef({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: `tags/${NEW_FLUTTER_VERSION}`,
+    })
+    return
+  } catch (error) {
+    if (error.status !== 404) throw error
+  }
+
   // Create a git tag using the GitHub API instead of the git client to skip SSH/GPG key setup.
-  github.rest.git.createRef({
+  await github.rest.git.createRef({
     owner: context.repo.owner,
     repo: context.repo.repo,
     ref: `refs/tags/${NEW_FLUTTER_VERSION}`,


### PR DESCRIPTION
Repository variables are not exposed to PRs from forks, so jobs that
reference vars.FLUTTER_VERSION at the container.image level fail to
resolve and the workflow template errors out before any step runs.
Replace it with a setup job that reads the latest published release tag
via the GitHub API using the read-only GITHUB_TOKEN, which is available
in fork-PR contexts.

- build.yml: add setup job, wire test_gradle to needs.setup.outputs;
  rewrite build_docs to drop the fork-unreachable commit-back step and
  upload the generated docs as an artifact reviewers can download
- release.yml: drop the set_bootstrap_image job that maintained the
  now-removed repository variable
- update_version.yml: same setup-job pattern for update_android_version
- tag.yml + createGitTag.js: stop comparing against vars.FLUTTER_VERSION;
  instead check whether a tag for the new version already exists
- update_docs.yml: new workflow on push:main that regenerates and
  commits documentation, replacing the per-PR commit-back behavior