### PR TITLE
fix(docs): bump transitive uuid to patched 11.1.1 (CVE-2026-41907)

### DIFF
--- a/docs/src/pnpm-lock.yaml
+++ b/docs/src/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  uuid: ^11.1.1
+
 importers:
 
   .:
@@ -814,9 +817,8 @@ packages:
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   vfile-message@4.0.3:
@@ -1488,7 +1490,7 @@ snapshots:
       gray-matter: 4.0.3
       remark-frontmatter: 5.0.0
       remark-mdx-frontmatter: 4.0.0
-      uuid: 9.0.1
+      uuid: 11.1.1
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -2003,7 +2005,7 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  uuid@9.0.1: {}
+  uuid@11.1.1: {}
 
   vfile-message@4.0.3:
     dependencies:

--- a/docs/src/pnpm-workspace.yaml
+++ b/docs/src/pnpm-workspace.yaml
@@ -1,2 +1,15 @@
 allowBuilds:
   esbuild: true
+
+# Force the transitive uuid past the patched line for GHSA-w5hq-g745-h8pq
+# (CVE-2026-41907). mdx-bundler@10.1.1 pins uuid@^9.0.1 and has no fixed
+# release; only uuid >= 11.1.1 is patched. mdx-bundler uses uuid via CommonJS
+# require() and only calls v4(), so the v11 bump is API-compatible.
+overrides:
+  uuid: ^11.1.1
+
+# Exempt uuid from the global minimumReleaseAge quarantine: every patched
+# release (>= 11.1.1) is newer than the 30-day cutoff, and the override above
+# IS the security remediation, so the fix must be allowed through.
+minimumReleaseAgeExclude:
+  - uuid


### PR DESCRIPTION
## What

Forces the transitive `uuid` dependency in the docs build tooling to the patched `11.1.1`, resolving **Dependabot alert #12** ([GHSA-w5hq-g745-h8pq](https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq) / CVE-2026-41907 — out-of-bounds write).

## Why a pnpm override

The dependency chain is:

```
docs/src → mdx-to-md@0.5.2 → mdx-bundler@10.1.1 → uuid@9.0.1  (flagged, < 11.1.1)
```

`mdx-bundler@latest` **is** `10.1.1` and still pins `uuid@^9.0.1` — there's no upstream release to bump to, and uuid has no patched 9.x/10.x line. So the version must be forced via a pnpm `override`.

**Compatibility:** `mdx-bundler` consumes uuid through CommonJS `require()` and only calls `v4()` (to name a temp entry file). uuid@11.1.1 still ships a CJS build with the `v4` named export, so the bump is API-compatible. The vulnerability itself (`v3`/`v5`/`v6` with a caller-supplied buffer) was never reachable here.

## minimumReleaseAge exemption

Every patched uuid release (≥ 11.1.1) was published in late April 2026, newer than the repo's 30-day `minimumReleaseAge` quarantine. Since the override *is* the security remediation, `uuid` is added to `minimumReleaseAgeExclude` so the fix can land; all other packages remain gated.

## Verification

- ✅ `uuid` resolves to `11.1.1` in `pnpm-lock.yaml`
- ✅ `pnpm install --frozen-lockfile` passes (matches `update_docs.yml` CI)
- ✅ pnpm supply-chain policy check passes
- ✅ `pnpm run build` regenerates all docs **identically** — no behavior change

Closes Dependabot alert #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)