### PR TITLE
fix(ci): tolerate locked files in Windows disk cleanup

### DIFF
--- a/.github/actions/clean-runner-disk/action.yml
+++ b/.github/actions/clean-runner-disk/action.yml
@@ -140,12 +140,36 @@ runs:
 
         # ForEach-Object -Parallel (PS7) removes directories concurrently without
         # subprocess overhead. ThrottleLimit 8 keeps I/O pressure reasonable.
+        #
+        # Each removal is wrapped in try/catch so a single locked/denied file (e.g.
+        # Firefox's crashhelper.exe holding an open handle) reclaims what it can and
+        # logs a warning, instead of surfacing a terminating Access-denied error out
+        # of the parallel runspace and failing the whole cleanup step. -ErrorAction
+        # Continue is unreliable inside -Parallel; an explicit catch is deterministic.
         $paths | Where-Object { Test-Path -LiteralPath $_ } | ForEach-Object -Parallel {
           $p = $_
           Write-Host "Removing $p"
-          Remove-Item -LiteralPath $p -Recurse -Force -ErrorAction Continue
+          # Try the whole tree first; on a locked file this throws before reclaiming
+          # the unlocked siblings, so fall back to deleting children individually so
+          # one denied file (e.g. Firefox's crashhelper.exe) can't block the rest.
+          try {
+            Remove-Item -LiteralPath $p -Recurse -Force -ErrorAction Stop
+          }
+          catch {
+            Write-Host "::warning::clean-runner-disk: bulk remove of $p failed ($($_.Exception.Message)); retrying per-item"
+            Get-ChildItem -LiteralPath $p -Recurse -Force -ErrorAction SilentlyContinue |
+              Sort-Object FullName -Descending |
+              ForEach-Object {
+                try {
+                  Remove-Item -LiteralPath $_.FullName -Force -Recurse -ErrorAction Stop
+                }
+                catch {
+                  Write-Host "::warning::clean-runner-disk: skipped locked path $($_.FullName)"
+                }
+              }
+          }
           if (Test-Path -LiteralPath $p) {
-            Write-Host "::warning::$p still present after removal"
+            Write-Host "::warning::clean-runner-disk: $p still present after removal (likely a locked file)"
           }
         } -ThrottleLimit 8
 


### PR DESCRIPTION
## Problem

`Test Windows image` failed at the `Clean runner disk` step (e.g. [run 26781471656](https://github.com/gmeligio/flutter-docker-image/actions/runs/26781471656/job/78946657734)):

```
Remove-Item 'C:\Program Files\Mozilla Firefox' ...
  → Access to the path 'C:\Program Files\Mozilla Firefox\crashhelper.exe' is denied.
Process completed with exit code 1.
...
clean-runner-disk: only 38.6 GB free on C:, expected >= 40 GB.
```

Firefox's `crashhelper.exe` holds an open handle, so `-Force` can't delete it. The bulk `Remove-Item -Recurse` threw an Access-denied **terminating** error out of the `ForEach-Object -Parallel` runspace (where `-ErrorAction Continue` is unreliable), failing the cleanup step. As a side effect the Firefox directory wasn't reclaimed, leaving the runner 1.4 GB under the 40 GB free-space gate.

## Fix

Wrap each path's removal in `try/catch`:

- On a bulk-remove failure, **retry per-item** (children first, depth-first) so unlocked siblings are still reclaimed — one locked file no longer blocks the rest of the directory.
- Log a `::warning::` for each skipped locked path instead of failing the step.

The cleanup now reclaims everything reclaimable and only the genuinely-locked file is left behind, so the step no longer fails spuriously on these (migrating) `windows-2025` runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)