### PR TITLE
ci(update-version): provide jq via mise in android job container

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -272,6 +272,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
+      # Set up early: the flutter-android container does not ship jq, which the
+      # Export FLUTTER_* and Stage android-only fragment steps below rely on.
+      # mise provides it (and cue) independent of the container image.
+      - name: Setup mise tools
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
       # TODO: Workaround because actions/download-artifact can't overwrite existing files
       # Check if this workaround can be removed after the following issues are fixed:
       # https://github.com/actions/download-artifact/issues/225
@@ -326,9 +332,6 @@ jobs:
       - name: Clean test application
         run: |
           rm -rf test_app
-
-      - name: Setup mise tools
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Generate test files with CUE
         run: |

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,9 @@
 [tools]
 cue = "0.15.0"
 git-cliff = "2.10.1"
+# jq is needed by the update-android-version job, whose flutter-android
+# container does not ship it; mise provides it independent of the image.
+jq = "1.8.1"
 pnpm = "11.2.2"
 node = "lts"
 "github:gmeligio/gx" = "0.8.2"


### PR DESCRIPTION
The update-android-version job runs inside the flutter-android image, which doesn't ship jq, so the Export FLUTTER_* step (and the later fragment step) died with "jq: not found" ([failing run](https://github.com/gmeligio/flutter-docker-image/actions/runs/27517986487/job/81330204932)). The job pulls the latest released image to compute the next version, so adding jq to the Dockerfile wouldn't fix the next run. Declare jq in mise.toml and move the existing mise setup ahead of the first jq use so the tool comes from mise regardless of what the container provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)