### PR TITLE
refactor(ci): hoist Setup mise tools into the setup block across all jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,6 +228,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
+      - name: Setup mise tools
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
       - name: Clean runner disk
         if: needs.build-image.outputs.image_artifact != ''
         uses: ./.github/actions/clean-runner-disk
@@ -253,9 +256,6 @@ jobs:
       - name: Pull image from registry
         if: needs.build-image.outputs.image_artifact == ''
         run: docker pull "ghcr.io/${{ github.repository_owner }}/flutter-android:${{ needs.build-image.outputs.image_tag }}"
-
-      - name: Setup mise tools
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Test image
         run: container-structure-test test --image "${{ needs.build-image.outputs.image_artifact != '' && needs.build-image.outputs.image_local_tag || format('ghcr.io/{0}/flutter-android:{1}', github.repository_owner, needs.build-image.outputs.image_tag) }}" --config test/android.yml
@@ -411,6 +411,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
+      - name: Setup mise tools
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
       - name: Read version.json
         id: version-json
         run: |
@@ -440,9 +443,6 @@ jobs:
         run: |
           cat ../../script/updateAndroidVersions.gradle.kts >> app/build.gradle.kts
           ./gradlew --warning-mode all updateAndroidVersions
-
-      - name: Setup mise tools
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Validate version.json with CUE
         run: cue vet config/schema.cue -d '#Version' config/version.json

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -272,9 +272,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      # Set up early: the flutter-android container does not ship jq, which the
-      # Export FLUTTER_* and Stage android-only fragment steps below rely on.
-      # mise provides it (and cue) independent of the container image.
       - name: Setup mise tools
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
@@ -388,6 +385,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
+      - name: Setup mise tools
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
       # The if gate guarantees the upstream upload ran, so the fragment always exists.
       - name: Delete flutter_version.json
         run: rm ${{ env.FLUTTER_VERSION_PATH }}
@@ -427,9 +427,6 @@ jobs:
           artifact-ids: ${{ steps.fragment_ids.outputs.ids }}
           path: ${{ runner.temp }}/fragments
           merge-multiple: true
-
-      - name: Setup mise tools
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       # Overlay each block in turn. Flutter always overlays; android (+fastlane)
       # and windows overlay only when their fragment was downloaded, else the base
@@ -495,6 +492,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
+      - name: Setup mise tools
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
       # TODO: Workaround because actions/download-artifact can't overwrite existing files
       # Check if this workaround can be removed after the following issues are fixed:
       # https://github.com/actions/download-artifact/issues/225
@@ -510,9 +510,6 @@ jobs:
         with:
           artifact-ids: ${{ needs.compose-version-manifest.outputs.composed_artifact_id }}
           path: .
-
-      - name: Setup mise tools
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Validate version.json with CUE
         run: cue vet config/schema.cue -d '#Version' config/version.json
@@ -553,6 +550,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Setup mise tools
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
       # TODO: Workaround because actions/download-artifact can't overwrite existing files
       # Check if this workaround can be removed after the following issues are fixed:
       # https://github.com/actions/download-artifact/issues/225
@@ -570,9 +570,6 @@ jobs:
         with:
           artifact-ids: ${{ needs.compose-version-manifest.outputs.composed_artifact_id }}
           path: .
-
-      - name: Setup mise tools
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Update documentation
         run: mise run docs

--- a/mise.toml
+++ b/mise.toml
@@ -1,8 +1,7 @@
 [tools]
 cue = "0.15.0"
 git-cliff = "2.10.1"
-# jq is needed by the update-android-version job, whose flutter-android
-# container does not ship it; mise provides it independent of the image.
+# For update-android-version: the flutter-android container lacks jq.
 jq = "1.8.1"
 pnpm = "11.2.2"
 node = "lts"


### PR DESCRIPTION
## Summary

Makes every workflow job set up its toolchain the same way: `harden runner → checkout → setup mise`, with `Setup mise tools` always in the setup block rather than buried mid-job.

Closes #495.

## Why

`mise` only puts tools (`cue`, `jq`, …) on `PATH` from the `Setup mise tools` step onward. Several jobs placed that step mid-job, right before the first tool use. On host runners this worked only by coincidence — the runner image preinstalls tools like `jq`, so a step running before `mise` still found them. Placement carried meaning by luck, not by structure. That latent foot-gun became a real failure in the container-based `update-android-version` job (`jq: not found`), fixed in #494.

The durable fix is uniformity: once every job opens with the same setup block, step order itself expresses "the toolchain is provisioned before any step uses it", and the next job author copies a container-safe pattern by default — no new abstraction, lint, or doc to keep in sync.

## Changes

- **Hoist 5 remaining `Setup mise tools` steps** into their job's setup block:
  - `build.yml` — Test image job, version-validation job
  - `update-version.yml` — `compose-version-manifest`, `validate-config-version`, `update-docs-and-create-pr`
- **Comment cleanup carried over from #494**: drop the 3-line workflow comment above the android-job mise step (placement is now self-evident) and shorten the `mise.toml` comment to a single line.

## Safety

- Every hoisted step is in a **host-runner** job where the tool is preinstalled or used by the very next step → **behavior-neutral**.
- **Pure step reordering** — no `uses:`/SHA-pin changes — so `gx lint` and the lock are unaffected; no `gx tidy` required.
- Both workflows validated as parseable YAML; the hoist diff is balanced (equal insertions/deletions per site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqVVPZVW9CZ525nsnXisDX)_