### PR TITLE
docs: drop outdated fastlane usage block from readme

### DIFF
--- a/docs/src/content.mdx
+++ b/docs/src/content.mdx
@@ -86,17 +86,6 @@ On a `.gitlab-ci.yml` in GitLab CI:
       - flutter build apk`}
 </code></pre>
 
-Fastlane:
-<pre><code className="language-bash">
-{`# Ruby bundler is available in the container.
-# The fastlane gem is cached but not installed
-# For more information, see https://docs.fastlane.tools
-
-# Use --prefer-local to download gems only if they are not cached
-bundle install --prefer-local
-bundle exec fastlane`}
-</code></pre>
-
 For Flutter web apps, use the `flutter-web` image:
 
 | Registry                  | flutter-web                                            |

--- a/readme.md
+++ b/readme.md
@@ -82,18 +82,6 @@ build:
     - flutter build apk
 ```
 
-Fastlane:
-
-```bash
-# Ruby bundler is available in the container.
-# The fastlane gem is cached but not installed
-# For more information, see https://docs.fastlane.tools
-
-# Use --prefer-local to download gems only if they are not cached
-bundle install --prefer-local
-bundle exec fastlane
-```
-
 For Flutter web apps, use the `flutter-web` image:
 
 | Registry                  | flutter-web                                                                                                        |


### PR DESCRIPTION
## Why

The readme's Fastlane usage block described the old bundler-based setup. Since #490/#491 (commit `f16ef2e`), the `fastlane` stage dropped the bundler indirection and installs fastlane globally:

```dockerfile
RUN gem install --no-document --version "$fastlane_version" fastlane \
    && gem install --no-document multi_json
```

So the documented workflow was wrong on two counts:

- **"The fastlane gem is cached but not installed"** — it *is* installed now.
- **`bundle install --prefer-local` + `bundle exec fastlane`** — there's no Gemfile/bundler project; the binstub is on `PATH` via `GEM_HOME/bin`.

## What

Rather than rewrite the block to say "run `fastlane`", it's removed entirely. With the bundler ceremony gone, invoking fastlane is identical to every other tool in the image (no `flutter` usage block exists either) — documenting the obvious implies a trick that isn't there.

The **`Fastlane: 2.236.1`** version line in the tool list is kept — that's the one fastlane fact a CI user actually needs (the image ships fastlane, at this version).

## Notes

- Source edit is in `docs/src/content.mdx`; `readme.md` is regenerated via `pnpm build` (it's auto-generated — direct edits get overwritten).
- A stale parallel claim in `docs/src/contributing.mdx:63` ("the `fastlane` stage … doesn't install fastlane") is **not** touched here since it doesn't render into the readme — happy to fold it in if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh2iSTQQauTv67ekrnzg1E)_