### PR TITLE
docs: correct fastlane stage description in contributing

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -63,6 +63,6 @@ When adding new Github Actions the `.github\renovate.json` needs to be checked a
 
 ### Dockerfile stages
 
-1. `flutter` stage hast only the dependencies required to install flutter and common tools used by flutter internal commands, like `git`.
-2. `fastlane` stage has the dependencies required to install fastlane but doesn't install fastlane.
+1. `flutter` stage has only the dependencies required to install flutter and common tools used by flutter internal commands, like `git`.
+2. `fastlane` stage installs Ruby and the build tools fastlane needs, then installs the fastlane gem.
 3. `android` stage has the dependencies required to install the Android SDK and to develop Flutter apps for Android.

--- a/docs/src/contributing.mdx
+++ b/docs/src/contributing.mdx
@@ -59,6 +59,6 @@ When adding new Github Actions the `.github\renovate.json` needs to be checked a
 
 ### Dockerfile stages
 
-1. `flutter` stage hast only the dependencies required to install flutter and common tools used by flutter internal commands, like `git`.
-2. `fastlane` stage has the dependencies required to install fastlane but doesn't install fastlane.
+1. `flutter` stage has only the dependencies required to install flutter and common tools used by flutter internal commands, like `git`.
+2. `fastlane` stage installs Ruby and the build tools fastlane needs, then installs the fastlane gem.
 3. `android` stage has the dependencies required to install the Android SDK and to develop Flutter apps for Android.


### PR DESCRIPTION
## Why

Follow-up to #505. The contributing doc's Dockerfile-stages list still described the pre-#490/#491 bundler setup:

> 2. `fastlane` stage has the dependencies required to install fastlane but doesn't install fastlane.

Since #490/#491, the stage installs the fastlane gem directly (`gem install … fastlane` + `multi_json`), so "doesn't install fastlane" is wrong.

## What

- Rewrite bullet 2 to match reality and the sibling bullets' "stage does X" phrasing:
  > 2. `fastlane` stage installs Ruby and the build tools fastlane needs, then installs the fastlane gem.
- Fix a `hast` → `has` typo in the adjacent `flutter` bullet while in there.

Source edit is in `docs/src/contributing.mdx`; `docs/contributing.md` is regenerated via `pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh2iSTQQauTv67ekrnzg1E)_