### PR TITLE
ci(renovate): use rangeStrategy bump so in-range action upgrades fire

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,9 +15,10 @@
       "enabled": false
     },
     {
-      "description": "Schedule gx.toml-driven action major upgrades on the first day of the month",
+      "description": "Schedule gx.toml-driven action upgrades on the first day of the month. rangeStrategy 'bump' raises the specifier lower bound for in-range (minor/patch) updates too — 'replace' (the default) only fires on out-of-range majors, so minor/patch bumps would never reach gx.toml or the lock.",
       "matchFileNames": [".github/gx.toml"],
       "groupName": "github-actions",
+      "rangeStrategy": "bump",
       "schedule": ["* 0-3 1 * *"]
     }
   ],


### PR DESCRIPTION
## Problem

The `gx.toml` custom manager relied on Renovate's default `rangeStrategy` (`replace`), which only edits a range when the new version falls **outside** it. With broad specifiers like `"actions/checkout" = "^7"`, minor/patch releases (e.g. `v7.1.0`) stay in range, so `replace` is a no-op — and `gx tidy` won't re-resolve a lock entry it considers complete. Result: **only major (out-of-range) upgrades ever reached `gx.toml` and the lock.** Minor/patch action updates were silently dropped.

## Fix

Set `rangeStrategy: "bump"` on the `.github/gx.toml` package rule. `bump` raises the specifier lower bound on in-range updates too (`^7.0.0` → `^7.1.0`), so minor/patch upgrades now open a PR and flow through the `gx.yml` `tidy` job like majors already do.

`rangeStrategy` is disallowed inside `customManagers` (config validator rejects it), so it lives on the packageRule scoped to `.github/gx.toml`.

## Verification

- `script/renovate_validate.sh` (strict) passes.
- Renovate dry-run against the working tree (results in PR thread).

## Follow-ups (gx repo)

Root cause + evolution tracked upstream: gmeligio/gx#109 (lint guardrail + docs), gmeligio/gx#110 (standalone delivery), gmeligio/gx#111 (`gx renovate init`).