### PR TITLE
feat(ci): adopt create-github-app-token v3 client-id input

### DIFF
--- a/.github/gx.lock
+++ b/.github/gx.lock
@@ -1,8 +1,8 @@
 [resolutions."actions/checkout"."^6"]
 version = "v6.0.1"
 
-[resolutions."actions/create-github-app-token"."^2"]
-version = "v2.2.1"
+[resolutions."actions/create-github-app-token"."^3.0.0"]
+version = "v3.2.0"
 
 [resolutions."actions/download-artifact"."^6"]
 version = "v6.0.0"
@@ -55,11 +55,11 @@ repository = "actions/checkout"
 ref_type = "tag"
 date = "2025-12-02T02:08:49Z"
 
-[actions."actions/create-github-app-token"."v2.2.1"]
-sha = "29824e69f54612133e76f7eaac726eef6c875baf"
+[actions."actions/create-github-app-token"."v3.2.0"]
+sha = "bcd2ba49218906704ab6c1aa796996da409d3eb1"
 repository = "actions/create-github-app-token"
 ref_type = "tag"
-date = "2025-12-05T22:53:03Z"
+date = "2026-05-12T23:31:18Z"
 
 [actions."actions/download-artifact"."v6.0.0"]
 sha = "018cc2cf5baa6db3ef3c5f8a56943fffe632ef53"

--- a/.github/gx.toml
+++ b/.github/gx.toml
@@ -1,6 +1,6 @@
 [actions]
 "actions/checkout" = "^6"
-"actions/create-github-app-token" = "^2"
+"actions/create-github-app-token" = "^3.0.0"
 "actions/download-artifact" = "^6"
 "actions/github-script" = "^8"
 "actions/upload-artifact" = "^5"

--- a/.github/workflows/gx.yml
+++ b/.github/workflows/gx.yml
@@ -52,10 +52,10 @@ jobs:
           egress-policy: audit
 
       - name: Generate authentication token with GitHub App to trigger Actions
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.VERIFIED_COMMIT_ID }}
+          client-id: ${{ secrets.VERIFIED_COMMIT_CLIENT_ID }}
           private-key: ${{ secrets.VERIFIED_COMMIT_KEY }}
           repositories: ${{ github.event.repository.name }}
           owner: ${{ github.repository_owner }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -41,10 +41,10 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Generate authentication token with GitHub App to trigger Actions
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.VERIFIED_COMMIT_ID }}
+          client-id: ${{ secrets.VERIFIED_COMMIT_CLIENT_ID }}
           private-key: ${{ secrets.VERIFIED_COMMIT_KEY }}
           repositories: ${{ github.event.repository.name }}
           owner: ${{ github.repository_owner }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -72,10 +72,10 @@ jobs:
           egress-policy: audit
 
       - name: Generate authentication token with GitHub App to trigger Actions
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.VERIFIED_COMMIT_ID }}
+          client-id: ${{ secrets.VERIFIED_COMMIT_CLIENT_ID }}
           private-key: ${{ secrets.VERIFIED_COMMIT_KEY }}
           repositories: ${{ github.event.repository.name }}
           owner: ${{ github.repository_owner }}

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -438,10 +438,10 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Generate authentication token with GitHub App to trigger Actions
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.VERIFIED_COMMIT_ID }}
+          client-id: ${{ secrets.VERIFIED_COMMIT_CLIENT_ID }}
           private-key: ${{ secrets.VERIFIED_COMMIT_KEY }}
           repositories: ${{ github.event.repository.name }}
           owner: ${{ github.repository_owner }}


### PR DESCRIPTION
## What

Adopts the non-deprecated `client-id` input of `actions/create-github-app-token` and bumps the action from **v2.2.1** to **v3.2.0**.

- `client-id` was added and `app-id` deprecated in [v3.1.0](https://github.com/actions/create-github-app-token/releases/tag/v3.1.0). `app-id` still works for now, but `client-id` is the future-proof input.
- `.github/gx.toml`: constraint `^2` → `^3.0.0`.
- `.github/gx.lock`: re-resolved via `gx tidy` to **v3.2.0** (SHA `bcd2ba49218906704ab6c1aa796996da409d3eb1`). Only this action's lock entry changed.
- All 4 workflows that use the action bump the SHA pin and switch `app-id` → `client-id`:
  - `.github/workflows/gx.yml`
  - `.github/workflows/prepare-release.yml`
  - `.github/workflows/update-docs.yml`
  - `.github/workflows/update-version.yml`

## ⚠️ REQUIRED manual step before merge — add a new repo secret

A GitHub App's numeric **App ID** and its **Client ID** (`Iv23...`) are **different values**. The existing `VERIFIED_COMMIT_ID` secret holds an App ID and cannot be passed to `client-id`.

To make this unambiguous, the workflows now read a **new** secret named **`VERIFIED_COMMIT_CLIENT_ID`** (rather than reusing `VERIFIED_COMMIT_ID`).

**Before merging, add a `VERIFIED_COMMIT_CLIENT_ID` repository secret** holding the GitHub App's **Client ID** (format `Iv23...`, found on the App's settings page). Without it, token generation fails at runtime.

The `private-key: ${{ secrets.VERIFIED_COMMIT_KEY }}` input is unchanged.

## Note on CI for this PR

Until the `VERIFIED_COMMIT_CLIENT_ID` secret is populated, this PR's own `gx` job will **fail at the token-generation step**. That is expected for this draft and clears once the secret is added.

## Verification

- `gx tidy` — clean, only the create-github-app-token entry changed.
- `gx lint` — no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
