### PR TITLE
chore(deps): bump artifact actions to upload v7 / download v8

### DIFF
--- a/.github/gx.lock
+++ b/.github/gx.lock
@@ -4,14 +4,14 @@ version = "v6.0.1"
 [resolutions."actions/create-github-app-token"."^2"]
 version = "v2.2.1"
 
-[resolutions."actions/download-artifact"."^6"]
-version = "v6.0.0"
+[resolutions."actions/download-artifact"."^8"]
+version = "v8"
 
 [resolutions."actions/github-script"."^8"]
 version = "v8.0.0"
 
-[resolutions."actions/upload-artifact"."^5"]
-version = "v5.0.0"
+[resolutions."actions/upload-artifact"."^7"]
+version = "v7"
 
 [resolutions."docker/build-push-action"."^6"]
 version = "v6.18.0"
@@ -61,11 +61,11 @@ repository = "actions/create-github-app-token"
 ref_type = "tag"
 date = "2025-12-05T22:53:03Z"
 
-[actions."actions/download-artifact"."v6.0.0"]
-sha = "018cc2cf5baa6db3ef3c5f8a56943fffe632ef53"
+[actions."actions/download-artifact".v8]
+sha = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
 repository = "actions/download-artifact"
 ref_type = "tag"
-date = "2025-10-24T18:15:38Z"
+date = "2026-03-11T15:35:54Z"
 
 [actions."actions/github-script"."v8.0.0"]
 sha = "ed597411d8f924073f98dfc5c65a23a2325f34cd"
@@ -73,11 +73,11 @@ repository = "actions/github-script"
 ref_type = "tag"
 date = "2025-09-04T14:48:16Z"
 
-[actions."actions/upload-artifact"."v5.0.0"]
-sha = "330a01c490aca151604b8cf639adc76d48f6c5d4"
+[actions."actions/upload-artifact".v7]
+sha = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
 repository = "actions/upload-artifact"
 ref_type = "tag"
-date = "2025-10-24T18:15:34Z"
+date = "2026-04-10T16:08:32Z"
 
 [actions."docker/build-push-action"."v6.18.0"]
 sha = "263435318d21b8e681c14492fe198d362a7d2c83"

--- a/.github/gx.toml
+++ b/.github/gx.toml
@@ -1,9 +1,9 @@
 [actions]
 "actions/checkout" = "^6"
 "actions/create-github-app-token" = "^2"
-"actions/download-artifact" = "^6"
+"actions/download-artifact" = "^8"
 "actions/github-script" = "^8"
-"actions/upload-artifact" = "^5"
+"actions/upload-artifact" = "^7"
 "docker/build-push-action" = "^6"
 "docker/login-action" = "^3"
 "docker/metadata-action" = "^5"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,7 +206,7 @@ jobs:
       # do not overwrite each other's upload (artifact names are run-global).
       - name: Upload image artifact
         if: steps.handoff.outputs.is_fork == 'true'
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: image-${{ github.run_id }}-${{ matrix.name }}
           path: image.tar.gz
@@ -252,7 +252,7 @@ jobs:
 
       - name: Download image artifact
         if: env.IS_FORK == 'true'
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: image-${{ github.run_id }}-${{ matrix.name }}
 
@@ -435,7 +435,7 @@ jobs:
       # handled by update-docs.yml on push to main — pushing to fork PR
       # branches is not possible with base-repo credentials.
       - name: Upload built docs
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docs-${{ github.event.pull_request.number || github.sha }}
           path: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -71,7 +71,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: Upload artifact
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -215,7 +215,7 @@ jobs:
       # do whenever the download steps completed before this step is reached).
       - name: Upload VS manifest artifacts for forensics
         if: always() && hashFiles('channel.json', 'vsman.json') != ''
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: vs-manifests
           path: |


### PR DESCRIPTION
## What

Bumps the two artifact actions to their new majors and re-pins every usage:

- `actions/upload-artifact` `^5 → ^7` — resolves to **v7.0.1** (`043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`)
- `actions/download-artifact` `^6 → ^8` — resolves to **v8.0.1** (`3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c`)

Done via `gx upgrade <action> --latest`; `gx lint` passes. Pins updated in `build.yml` (×3), `scorecard.yml` (×1), `update-version.yml` (×1), plus `gx.toml`/`gx.lock`. No unrelated actions touched.

## Why not adopt `archive: false` (direct upload)?

The v7/v8 majors add the "direct upload" feature the branch name references: `archive: false` on upload skips zipping a single file, and v8 download auto-skips unzip for non-zipped artifacts (Content-Type sniffing; `skip-decompress` only needed to keep a *zipped* file zipped). I evaluated every artifact site in the repo against the feature's documented constraints and **deliberately did not apply it anywhere** — no site is provably safe:

| Site | Payload | Verdict |
|---|---|---|
| `build.yml` `image.tar.gz` (fork handoff) | single file, but **downloaded by `name`** and both matrix legs write `image.tar.gz` | Unsafe. Per the [v7 docs](https://github.com/actions/upload-artifact/releases/tag/v7.0.0), `archive:false` **ignores `name`** and names the artifact after the file. Both `flutter-android`/`flutter-web` legs would upload an artifact literally named `image.tar.gz` — a run-global collision the existing `name: image-${run_id}-${matrix.name}` comment exists to prevent — and the download-by-name step would match nothing. Would require distinct per-leg filenames + updated download `name:` + updated `gunzip` target: a behavioral rewrite, not a version-safe swap. |
| `build.yml` `docs-*` | `readme.md` + `examples/` (multiple) | Unsafe. `archive:false` supports a **single file only** and fails on a multi-file glob. |
| `scorecard.yml` `results.sarif` | single file | Excluded by design — SARIF flows to `codeql-action/upload-sarif`, which expects standard artifact behavior. |
| `update-version.yml` `vs-manifests` | `channel.json` + `vsman.json` (multiple) | Unsafe. Multi-file → `archive:false` fails. Also never downloaded, so nothing to round-trip. |

## Verification (authoritative sources)

1. **Overwrite / `rm` workaround** — download-artifact issues [#225](https://github.com/actions/download-artifact/issues/225) and [#138](https://github.com/actions/download-artifact/issues/138) are still **open**; v8 adds no `overwrite` input. The overwrite limitation is unchanged. (Moot here — no `rm`-overwrite workaround exists on `main`.)
2. **`archive:false` ignores `name`, single-file only** — confirmed by the [v7.0.0 release notes](https://github.com/actions/upload-artifact/releases/tag/v7.0.0) and README: *"only a single file can be uploaded. The name of the file will be used as the artifact name (the 'name' parameter is ignored)."*
3. **v8 auto-skips unzip for non-zipped artifacts** — confirmed by the [v8.0.0 release notes](https://github.com/actions/download-artifact/releases/tag/v8.0.0): checks `Content-Type` before unzipping; `skip-decompress: true` only to keep a zipped file zipped.
4. **`merge-multiple` + `archive:false`** — no `merge-multiple` usage exists in the repo; N/A.

## Heads-up: v8 breaking change (safe here)

download-artifact v8 defaults `digest-mismatch` to `error` (was warning). The one download (`build.yml` `image.tar.gz`) is a standard artifact round-trip; digests match by default, so `error` only trips on genuine corruption — desirable, no action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
