### PR TITLE
fix(android): bump pinned openjdk-17-jdk-headless to 17.0.20+8-1~deb12u1

### DIFF
--- a/android.Dockerfile
+++ b/android.Dockerfile
@@ -141,7 +141,7 @@ ENV ANDROID_HOME="$SDK_ROOT/android-sdk" \
 ENV PATH="$PATH:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$HOME/.local/bin"
 
 # renovate: suite=bookworm depName=openjdk-17-jdk-headless
-ARG OPENJDK_17_JDK_HEADLESS_VERSION="17.0.19+10-1~deb12u2"
+ARG OPENJDK_17_JDK_HEADLESS_VERSION="17.0.20+8-1~deb12u1"
 # renovate: suite=trixie depName=sudo
 ARG SUDO_VERSION="1.9.16p2-3+deb13u2"
 


### PR DESCRIPTION
## Problem

CI on `main` fails in the **Test image** job, step *Build image and push to local Docker daemon* ([run 31078705754](https://github.com/gmeligio/flutter-docker-image/actions/runs/31078705754/job/92542338622)). The failure is in the `android` stage of `android.Dockerfile:151`:

```
#15 [android 2/8] RUN apt-get update && apt-get install -y --no-install-recommends \
      openjdk-17-jdk-headless="17.0.19+10-1~deb12u2" sudo="1.9.16p2-3+deb13u2" ...

#15 3.489 The following packages have unmet dependencies:
#15 3.489  openjdk-17-jdk-headless : Depends: openjdk-17-jre-headless (= 17.0.19+10-1~deb12u2)
                                     but 17.0.20+8-1~deb12u1 is to be installed
#15 3.492 E: Unable to correct problems, you have held broken packages.

ERROR: failed to build: failed to solve: process "/bin/bash -euxo pipefail -c apt-get update ..."
  did not complete successfully: exit code: 100
```

## Root cause

`openjdk-17-jdk-headless` carries a strict `Depends: openjdk-17-jre-headless (= <same version>)`, so the JDK and JRE binaries must be installed at the exact same version.

Only the JDK is pinned. Debian has since published `17.0.20+8-1~deb12u1` to the bookworm repositories this stage enables (`config/debian_12_bookworm.sources`), which became the candidate apt selects for `openjdk-17-jre-headless`, while the JDK stayed pinned at `17.0.19+10-1~deb12u2`. apt cannot satisfy the equality constraint across two different versions and aborts with exit code 100.

This is not a network or code problem — it is a pin that the archive has moved past.

## Change

Bump the pin so both binaries resolve to the same published version:

```diff
 # renovate: suite=bookworm depName=openjdk-17-jdk-headless
-ARG OPENJDK_17_JDK_HEADLESS_VERSION="17.0.19+10-1~deb12u2"
+ARG OPENJDK_17_JDK_HEADLESS_VERSION="17.0.20+8-1~deb12u1"
```

The target version is taken from the failing build's own apt output, which named `17.0.20+8-1~deb12u1` as the version available for `openjdk-17-jre-headless` in that exact repository set. `openjdk-17`'s binaries are published together from one source upload, so the JDK is available at the same version. This could not be confirmed locally (the dev sandbox has no egress to `deb.debian.org` and no Docker daemon) — **CI on this PR is the verification.**

## Follow-up: why Renovate did not catch this

This pin was introduced on 2026-05-25 and has never been bumped since, while the neighbouring `suite=trixie` pins (e.g. `SUDO_VERSION`) have been updated normally. The `deb` custom manager in `.github/renovate.json` builds its registry URL as:

```
https://deb.debian.org/debian?{{#if release }}release={{release}}{{else}}suite=stable{{/if}}&components=main,contrib,non-free&binaryArch=amd64
```

The annotation supplies `suite=…`, but the template branches on `release`, which the regex never captures — so the conditional always falls through to the hard-coded `suite=stable`. Every pin is therefore looked up against whatever *stable* currently is. That is now Debian 13 trixie, which is exactly why the `suite=trixie` pins keep working and this lone `suite=bookworm` pin silently went stale. The registry URL also covers only `deb.debian.org/debian`, not `deb.debian.org/debian-security`, where the `~deb12uN` updates for oldstable are published.

Deliberately left out of this PR to keep the CI fix reviewable on its own; tracked separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvH4a2ijDZLiaxMrUE95AL)_