### PR TITLE
docs: document registry setup required for a new published image

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -56,6 +56,20 @@ docker build --target linux --build-arg flutter_version=3.44.6 -t flutter-linux:
 docker build --target flutter --build-arg flutter_version=3.44.6 -t flutter-windows:local -f windows.Dockerfile .
 ```
 
+## Publishing a new image
+
+Wiring a new image into CI is a matrix entry in `build.yml` (build, test, scan), in `release.yml` (`release-linux`, `verify-published`, `update-description`, `record-image`), and in `cleanup-pr-image.yml`. The registry side is **not** automated: each registry needs a one-time manual setup, and skipping it fails the release run rather than the build.
+
+- **Docker Hub** — nothing to prepare. The first push auto-creates the repository, public by default. Check only that `DOCKER_HUB_TOKEN` is not restricted to a fixed set of repositories, because `update-description` writes the new repository's description with it.
+- **GHCR** — the package is **private** when first pushed. That is independent of the repository being public, and assuming otherwise once shipped an unpullable `flutter-android` ([issue #492](https://github.com/gmeligio/flutter-docker-image/issues/492)). In the package settings, set:
+  1. **Visibility: Public.** `verify-published` resolves every tag with anonymous auth only, so a private package fails the release even though the push succeeded.
+  2. **Manage Actions access: this repository, role Admin.** `cleanup-pr-image.yml` deletes the `pr-<N>` handoff versions through `/user/packages/container/<name>/versions` with `GITHUB_TOKEN`, which requires Admin.
+
+  Both are web-UI-only — no REST endpoint changes either one. The package first appears on the first non-fork `build.yml` run, which pushes the `pr-<N>` (or `branch-<ref>`) handoff tag, so any pull request from this repository creates it in time to fix the settings before the first release tag.
+- **Quay.io** — pre-create the repository as **public** and grant the robot account in `QUAY_USERNAME` write access on it. A repository auto-created by a push is private, and Quay robot permissions are per-repository, so an unprepared namespace fails either the push in `release-linux` or the anonymous check in `verify-published`.
+
+Each of those matrices is `fail-fast: false`, so a missed step reddens only the new image's legs and the other images still publish. Fix the setting and re-push the tag to publish forward.
+
 ## Editing GitHub Actions workflows
 
 GitHub Actions versions are tracked with [gx](https://github.com/gmeligio/gx). The manifest at `.github/gx.toml` is the source of truth for version constraints, and `.github/gx.lock` records the resolved SHAs. Workflows must use SHA pins with a `# vX.Y.Z` comment.


### PR DESCRIPTION
## Why

Adding an image to CI is a matrix entry in `build.yml`, `release.yml`, and `cleanup-pr-image.yml` — but each registry also needs a one-time **manual** setup that nothing in the repository records. That knowledge lived only in a closed issue (#492) and in section 6 of an archived OpenSpec task list (`openspec/changes/archive/2026-06-18-add-flutter-web-image/tasks.md`), so it was not carried over when `flutter-linux` was added in #551.

The failure mode is quiet: the build and the push succeed, and the release run goes red later in `verify-published`, which resolves each tag with anonymous auth only.

## What changes

One new `## Publishing a new image` section in `docs/contributing.md` (static Markdown — not generated, so `mise run docs` output is unaffected):

- **Docker Hub** — nothing to prepare; the first push auto-creates the repository, public by default. Only caveat is that the token must not be restricted to a fixed repository set, since `update-description` writes the new repository's description with it.
- **GHCR** — the package is private on first push, independent of repository visibility. Needs **Visibility: Public** (else `verify-published` fails) and **Manage Actions access: this repository, role Admin** (else `cleanup-pr-image.yml` cannot delete `pr-<N>` handoff versions). Both are web-UI-only; no REST endpoint changes either.
- **Quay.io** — pre-create the repository public and grant the `QUAY_USERNAME` robot write, since auto-created repositories are private and Quay robot permissions are per-repository.

Each bullet names the job that fails when the step is skipped, and the section closes on the blast radius: every one of those matrices is `fail-fast: false`, so a missed step reddens only the new image's legs.

## Status for `flutter-linux`

None of the three steps has been done yet — `gmeligio/flutter-linux` does not exist on Docker Hub (`object not found`), and the GHCR package has not been created because #551 came from a fork, so `build.yml` took the local-artifact path and never pushed a handoff tag.

This PR is also the mechanism for the GHCR half: it is a same-repo PR, so `build-image (flutter-linux)` pushes `ghcr.io/gmeligio/flutter-linux:pr-<N>`, which **creates the package**. Once the run finishes, the two settings above can be applied in the package UI ahead of the next release tag. `cleanup-pr-image.yml` deletes that handoff tag when this PR closes, so nothing is left behind.

## Testing

- No workflow or action files touched, so `gx tidy` is not required.
- `docs/contributing.md` is static per `mise.toml` and is not read by `docs/build.mjs` (it is only linked from `readme.md`), so `update-docs.yml`'s drift check is unaffected.
- No prettier/markdownlint gate exists in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3adgcDT1MCi2mwtgAjQwe)_