### PR TITLE
chore(renovate): drop unfetchable -updates registryUrls

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,7 +22,7 @@
       "schedule": ["* 0-3 1 * *"]
     },
     {
-      "description": "Default apt suites for debian:13-slim: trixie plus trixie-security. trixie-updates is omitted deliberately — no pin resolves from it, and Renovate cannot fetch it anyway (see below). Update these together with the base image in android.Dockerfile — a Debian release bump makes them stale. NOTE: Renovate's deb datasource hardcodes Packages.gz, but Debian publishes only Packages and Packages.xz on -security, so the trixie-security URL 404s on every run and is silently skipped. It is kept because it states correctly where apt resolves these packages from, and will start working with no edit once renovatebot/renovate#44330 (PR #35865) lands. Until then, script/check_deb_pins.sh is what actually verifies a pin is installable.",
+      "description": "Default apt suites for debian:13-slim: trixie plus trixie-security; trixie-updates is omitted, no pin resolves from it. Mirrors the base image's own sources — update these together with the base image in android.Dockerfile, since a Debian release bump makes them stale. The trixie-security URL currently 404s on every run and is silently skipped: Renovate's deb datasource hardcodes Packages.gz, which Debian does not publish on the delta suites (renovatebot/renovate#44330). It is kept because it records where apt really resolves these packages from, and starts working with no edit once that lands.",
       "matchDatasources": ["deb"],
       "registryUrls": [
         "https://deb.debian.org/debian?suite=trixie&components=main&binaryArch=amd64",
@@ -30,7 +30,7 @@
       ]
     },
     {
-      "description": "openjdk-17 is not in trixie; the android stage adds Debian 12 bookworm to install it. Mirrors config/debian_12_bookworm.sources, minus bookworm-updates, from which no pin resolves. bookworm-security is load-bearing, not optional: the only installable openjdk-17-jdk-headless is 17.0.20.1+1-1~deb12u1, published there and nowhere else, because a security upload moved openjdk-17-jre-headless and the JDK declares Depends: openjdk-17-jre-headless (= <same version>). Renovate cannot currently fetch it (hardcoded Packages.gz vs Debian's Packages.xz — renovatebot/renovate#44330), so this URL 404s and is silently skipped; it is kept because removing it would state that the pin comes from somewhere it does not, which is how #555 happened. Must stay after the trixie rule — a later matching rule replaces registryUrls.",
+      "description": "openjdk-17 is not in trixie; the android stage adds Debian 12 bookworm to install it. Mirrors config/debian_12_bookworm.sources, minus bookworm-updates, from which no pin resolves. bookworm-security is load-bearing, not optional: the only installable openjdk-17-jdk-headless is published there and nowhere else, because a security upload moved openjdk-17-jre-headless and the JDK declares Depends: openjdk-17-jre-headless (= <same version>) — see #555. Renovate cannot currently fetch it (hardcoded Packages.gz vs the Packages.xz Debian publishes on the delta suites — renovatebot/renovate#44330), so this URL 404s and is silently skipped; it is kept because removing it would state that the pin comes from somewhere it does not. Must stay after the trixie rule — a later matching rule replaces registryUrls.",
       "matchDatasources": ["deb"],
       "matchPackageNames": ["openjdk-17-jdk-headless"],
       "registryUrls": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,7 +22,7 @@
       "schedule": ["* 0-3 1 * *"]
     },
     {
-      "description": "Default apt suites for debian:13-slim: trixie plus trixie-security; trixie-updates is omitted, no pin resolves from it. Mirrors the base image's own sources — update these together with the base image in android.Dockerfile, since a Debian release bump makes them stale. The trixie-security URL currently 404s on every run and is silently skipped: Renovate's deb datasource hardcodes Packages.gz, which Debian does not publish on the delta suites (renovatebot/renovate#44330). It is kept because it records where apt really resolves these packages from, and starts working with no edit once that lands.",
+      "description": "Where the base image installs apt packages from: debian:13-slim's own suites. Keep in sync with the base image in android.Dockerfile.",
       "matchDatasources": ["deb"],
       "registryUrls": [
         "https://deb.debian.org/debian?suite=trixie&components=main&binaryArch=amd64",
@@ -30,7 +30,7 @@
       ]
     },
     {
-      "description": "openjdk-17 is not in trixie; the android stage adds Debian 12 bookworm to install it. Mirrors config/debian_12_bookworm.sources, minus bookworm-updates, from which no pin resolves. bookworm-security is load-bearing, not optional: the only installable openjdk-17-jdk-headless is published there and nowhere else, because a security upload moved openjdk-17-jre-headless and the JDK declares Depends: openjdk-17-jre-headless (= <same version>) — see #555. Renovate cannot currently fetch it (hardcoded Packages.gz vs the Packages.xz Debian publishes on the delta suites — renovatebot/renovate#44330), so this URL 404s and is silently skipped; it is kept because removing it would state that the pin comes from somewhere it does not. Must stay after the trixie rule — a later matching rule replaces registryUrls.",
+      "description": "Trixie has no openjdk-17, so the android stage adds bookworm to get it. Mirrors config/debian_12_bookworm.sources. The security suite is required, not a nicety — the only installable openjdk-17 comes from there (#555). Keep this rule last; a later match would replace the URLs above.",
       "matchDatasources": ["deb"],
       "matchPackageNames": ["openjdk-17-jdk-headless"],
       "registryUrls": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,21 +22,19 @@
       "schedule": ["* 0-3 1 * *"]
     },
     {
-      "description": "Default apt suites: one registryUrl per stanza of debian:13-slim's own sources (trixie, trixie-updates, trixie-security; main only). The deb datasource merges releases across them, so Renovate's candidate is the one apt would install. Update these together with the base image in android.Dockerfile — a Debian release bump makes them stale.",
+      "description": "Default apt suites for debian:13-slim: trixie plus trixie-security. trixie-updates is omitted deliberately — no pin resolves from it, and Renovate cannot fetch it anyway (see below). Update these together with the base image in android.Dockerfile — a Debian release bump makes them stale. NOTE: Renovate's deb datasource hardcodes Packages.gz, but Debian publishes only Packages and Packages.xz on -security, so the trixie-security URL 404s on every run and is silently skipped. It is kept because it states correctly where apt resolves these packages from, and will start working with no edit once renovatebot/renovate#44330 (PR #35865) lands. Until then, script/check_deb_pins.sh is what actually verifies a pin is installable.",
       "matchDatasources": ["deb"],
       "registryUrls": [
         "https://deb.debian.org/debian?suite=trixie&components=main&binaryArch=amd64",
-        "https://deb.debian.org/debian?suite=trixie-updates&components=main&binaryArch=amd64",
         "https://deb.debian.org/debian-security?suite=trixie-security&components=main&binaryArch=amd64"
       ]
     },
     {
-      "description": "openjdk-17 is not in trixie; the android stage adds Debian 12 bookworm to install it. Mirrors config/debian_12_bookworm.sources. Must stay after the trixie rule — a later matching rule replaces registryUrls.",
+      "description": "openjdk-17 is not in trixie; the android stage adds Debian 12 bookworm to install it. Mirrors config/debian_12_bookworm.sources, minus bookworm-updates, from which no pin resolves. bookworm-security is load-bearing, not optional: the only installable openjdk-17-jdk-headless is 17.0.20.1+1-1~deb12u1, published there and nowhere else, because a security upload moved openjdk-17-jre-headless and the JDK declares Depends: openjdk-17-jre-headless (= <same version>). Renovate cannot currently fetch it (hardcoded Packages.gz vs Debian's Packages.xz — renovatebot/renovate#44330), so this URL 404s and is silently skipped; it is kept because removing it would state that the pin comes from somewhere it does not, which is how #555 happened. Must stay after the trixie rule — a later matching rule replaces registryUrls.",
       "matchDatasources": ["deb"],
       "matchPackageNames": ["openjdk-17-jdk-headless"],
       "registryUrls": [
         "https://deb.debian.org/debian?suite=bookworm&components=main,contrib,non-free,non-free-firmware&binaryArch=amd64",
-        "https://deb.debian.org/debian?suite=bookworm-updates&components=main,contrib,non-free,non-free-firmware&binaryArch=amd64",
         "https://deb.debian.org/debian-security?suite=bookworm-security&components=main,contrib,non-free,non-free-firmware&binaryArch=amd64"
       ]
     }


### PR DESCRIPTION
Follow-up to #558, split out because `.github/renovate.json` ships on `renovate/reconfigure` per the branch convention.

## What changes

Drops `trixie-updates` and `bookworm-updates`. Keeps both `-security` entries and documents why they currently 404.

## Why keep suites that do not work

Renovate's deb datasource hardcodes the compression:

```ts
const compression = 'gz';   // not a parameter, not configurable
```

Debian publishes only `Packages` and `Packages.xz` on the delta suites, so every `-updates` and `-security` URL returns 404 on every run — 34 per job, swallowed at debug level while the job reports success. Verified against `ftp.debian.org`, `ftp.us.debian.org`, `archive.debian.org` and a third-party mirror: the `.gz` is gone everywhere. Upstream: [renovate#44330](https://github.com/renovatebot/renovate/issues/44330), [PR #35865](https://github.com/renovatebot/renovate/pull/35865) (open since 2025-05).

So both keeping and dropping them are wrong in different ways:

- **`-security` is load-bearing.** The only installable `openjdk-17-jdk-headless` is `17.0.20.1+1-1~deb12u1`, published there and nowhere else (see #558). Removing the URL would state that the pin comes from somewhere it does not — the same false-premise-in-config that produced #555. Kept, so coverage resumes with no edit when upstream lands `.xz`.
- **`-updates` is not.** Equally unfetchable, and no pin resolves from it. It asserts coverage with no corresponding need. Dropped.

Both `description` fields now name the upstream limitation, so the retained 404s read as an intentional gap rather than an oversight.

## Verification

`./script/renovate_validate.sh` passes — syntax only; it does not evaluate whether a suite is fetchable. The Renovate app validates authoritatively on this branch.

After this merges, the `-updates` 404s should be gone from the job log and pins should still resolve.